### PR TITLE
[HDXINFRA-240] capture the gisapi logs in a file

### DIFF
--- a/gisapi/Dockerfile
+++ b/gisapi/Dockerfile
@@ -4,7 +4,7 @@ MAINTAINER Serban Teodorescu, teodorescu.serban@gmail.com
 
 COPY run_gisapi settings.js.tpl /tmp/
 
-RUN mkdir -p /etc/service/gisapi /srv && \
+RUN mkdir -p /etc/service/gisapi /srv /var/log/gisapi && \
     mv /tmp/settings.js.tpl /srv/ && \
     mv /tmp/run_gisapi /etc/service/gisapi/run && \
     chmod +x /etc/service/gisapi/run && \

--- a/gisapi/run_gisapi
+++ b/gisapi/run_gisapi
@@ -2,4 +2,4 @@
 
 envsubst < /srv/settings.js.tpl > /srv/gisapi/settings/settings.js
 cd /srv/gisapi/
-exec nodejs app.js
+exec nodejs app.js > /var/log/gisapi/gisapi.log 2>&1


### PR DESCRIPTION
The reason is to reduce the space used under the radar on /var/lib/docker